### PR TITLE
chore: rename verify job til verify-hovmester-sync

### DIFF
--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  verify-and-merge:
+  verify-hovmester-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Rename job fra `verify-and-merge` til `verify-hovmester-sync` for tydeligere branch protection-check.

> **Merk:** Oppdater branch protection required check til `verify-hovmester-sync` etter merge.