### PR TITLE
fix(ci): add --repo flag to hovmester-verify

### DIFF
--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -18,6 +18,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.head_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -74,6 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr review "$PR_NUMBER" --approve --body "Auto-approved: file scope verified ✅"
-          gh pr merge "$PR_NUMBER" --auto --squash
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approved: file scope verified ✅"
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash


### PR DESCRIPTION
Fikser `fatal: not a git repository`-feil i verify-workflowen.

`gh pr review` og `gh pr merge` trenger `--repo`-flagget fordi workflowen bevisst ikke sjekker ut kode (`pull_request_target`-sikkerhet).