### PR TITLE
fix(ci): remove duplicate REPO env key in hovmester-verify

### DIFF
--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -18,7 +18,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.head_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## Summary
- remove the duplicate `REPO` env entry from the Verify file scope step
- keep the later `REPO` entry in that step and leave the auto-merge step unchanged

## Verification
- verified the Verify file scope env block contains exactly one `REPO` entry
- verified the Approve and enable auto-merge env block contains exactly one `REPO` entry