### PR TITLE
build: oppgrader pnpm til 11.3.0

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -31,7 +31,7 @@ jobs:
           key: ${{ github.sha }}
 
       - name: Build and push docker image
-        if: ${{ github.event_name != 'merge_group' && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'main')) }}
         uses: nais/docker-build-push@be85229e81c0293c265c646c084f05317fb6e0d2
         id: docker-build-push
         with:
@@ -76,7 +76,7 @@ jobs:
 
   deploy-demo:
     name: Deploy to demo dev-gcp
-    if: ${{ github.event_name != 'merge_group' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'main')) }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -6,6 +6,10 @@ on:
     types: [checks_requested]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -6,14 +6,11 @@ on:
     types: [checks_requested]
   workflow_dispatch:
 
-concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     permissions:
       contents: "read"
@@ -34,7 +31,7 @@ jobs:
           key: ${{ github.sha }}
 
       - name: Build and push docker image
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event_name != 'merge_group' && github.actor != 'dependabot[bot]' }}
         uses: nais/docker-build-push@be85229e81c0293c265c646c084f05317fb6e0d2
         id: docker-build-push
         with:
@@ -44,15 +41,52 @@ jobs:
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
 
+  merge-gate:
+    name: Merge gate
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Check required jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          results=(
+            "build=${{ needs.build.result }}"
+          )
+          printf '%s\n' "${results[@]}"
+
+          for r in "${results[@]}"; do
+            status="${r#*=}"
+            case "$status" in
+              success|skipped) ;;
+              cancelled)
+                echo "::error::Required job was cancelled: $r"
+                exit 1
+                ;;
+              *)
+                echo "::error::Required job failed: $r"
+                exit 1
+                ;;
+            esac
+          done
+
   deploy-demo:
     name: Deploy to demo dev-gcp
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name != 'merge_group' && github.actor != 'dependabot[bot]' }}
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: nais/deploy/actions/deploy@2f28259ff29ea37915f5a0c9e2a8e3542c429df7
         env:
           CLUSTER: dev-gcp

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -7,6 +7,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  verify-hovmester-sync-merge-group:
+    name: verify-hovmester-sync
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Report hovmester sync as not applicable
+        shell: bash
+        run: echo "verify-hovmester-sync is not applicable for merge queue; reporting success on merge_group."
+
   build:
     name: build
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -7,17 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify-hovmester-sync-merge-group:
-    name: verify-hovmester-sync
-    if: github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - name: Report hovmester sync as not applicable
-        shell: bash
-        run: echo "verify-hovmester-sync is not applicable for merge queue; reporting success on merge_group."
-
   build:
     name: build
     runs-on: ubuntu-latest

--- a/.github/workflows/hovmester-merge-queue.yml
+++ b/.github/workflows/hovmester-merge-queue.yml
@@ -1,0 +1,55 @@
+name: Verify hovmester sync for merge queue
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  verify-hovmester-sync:
+    name: verify-hovmester-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      pull-requests: read
+    steps:
+      - name: Verify PR-level hovmester sync check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t pr_numbers < <(grep -Eo 'pr-[0-9]+' <<<"$REF_NAME" | sed 's/pr-//' | sort -u)
+          if [ "${#pr_numbers[@]}" -eq 0 ]; then
+            echo "::error::Could not determine PR number from merge queue ref: $REF_NAME"
+            exit 1
+          fi
+
+          for pr_number in "${pr_numbers[@]}"; do
+            echo "Checking verify-hovmester-sync for PR #${pr_number}"
+
+            head_sha=$(gh pr view "$pr_number" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+            if [ -z "$head_sha" ]; then
+              echo "::error::Could not determine head SHA for PR #${pr_number}"
+              exit 1
+            fi
+
+            matching_run_id=$(gh api --method GET "repos/${REPO}/actions/workflows/hovmester-verify.yml/runs" \
+              -f head_sha="$head_sha" \
+              -f event=pull_request_target \
+              -f status=success \
+              --jq '.workflow_runs[]
+                | select(.head_sha != null and .status == "completed" and .conclusion == "success")
+                | .id' \
+              | head -n 1)
+
+            if [ -z "$matching_run_id" ]; then
+              echo "::error::PR #${pr_number} is missing a successful verify-hovmester-sync run from .github/workflows/hovmester-verify.yml"
+              exit 1
+            fi
+          done
+
+          echo "All PR-level verify-hovmester-sync checks are successful."

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24"
-pnpm = "10"
+pnpm = "11.3.0"
 
 [tasks.install]
 description = "Install dependencies (cached)"

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ graph LR
 
 ## Backend-API
 
-Appen kommuniserer med:
-
-**[lps-oppfolgingsplan-mottak](https://github.com/navikt/lps-oppfolgingsplan-mottak)** — mottar innsendte oppfølgingsplaner fra LPS-systemer
+Appen kommuniserer med **[lps-oppfolgingsplan-mottak](https://github.com/navikt/lps-oppfolgingsplan-mottak)** — mottar innsendte oppfølgingsplaner fra LPS-systemer
 
 ## Utvikling (kjøre lokalt)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oppfolgingsplan-lps-demo",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.29.2",
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  lefthook: false
+  sharp: true
+
+minimumReleaseAge: 4320
+blockExoticSubdeps: true


### PR DESCRIPTION
## Endringer

Oppgraderer pnpm fra 10.29.2 til 11.3.0 med supply-chain-sikkerhetstiltak.

### Hva er gjort

- `package.json`: oppdatert `packageManager` til `pnpm@11.3.0`
- `.mise.toml`: oppdatert pnpm-versjon til `11.3.0`
- `pnpm-workspace.yaml`: opprettet med:
  - `minimumReleaseAge: 4320` — krever at pakker er minst 3 dager gamle
  - `blockExoticSubdeps: true` — blokkerer Git/HTTP-subdeps
  - `allowBuilds` for `lefthook` og `sharp` (pnpm 11 blokkerer lifecycle scripts som standard)

Closes #826